### PR TITLE
Implement a replacement filter to cleanup private data in stored responses

### DIFF
--- a/src/Recorder/FilesystemRecorder.php
+++ b/src/Recorder/FilesystemRecorder.php
@@ -31,7 +31,12 @@ final class FilesystemRecorder implements RecorderInterface, PlayerInterface, Lo
      */
     private $filesystem;
 
-    public function __construct(string $directory, ?Filesystem $filesystem = null)
+    /**
+     * @var array
+     */
+    private $filters;
+
+    public function __construct(string $directory, ?Filesystem $filesystem = null, array $filters = [])
     {
         $this->filesystem = $filesystem ?? new Filesystem();
 
@@ -44,6 +49,7 @@ final class FilesystemRecorder implements RecorderInterface, PlayerInterface, Lo
         }
 
         $this->directory = realpath($directory).\DIRECTORY_SEPARATOR;
+        $this->filters = $filters;
     }
 
     public function replay(string $name): ?ResponseInterface
@@ -67,7 +73,8 @@ final class FilesystemRecorder implements RecorderInterface, PlayerInterface, Lo
         $filename = "{$this->directory}$name.txt";
         $context = compact('name', 'filename');
 
-        $this->filesystem->dumpFile($filename, Psr7\str($response));
+        $content = preg_replace(array_keys($this->filters), array_values($this->filters), Psr7\str($response));
+        $this->filesystem->dumpFile($filename, $content);
 
         $this->log('Response for {name} stored into {filename}', $context);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Add a filter by regular expression in filesystemRecorder responses


#### Why?

to not store private data in commited responses


#### Example Usage

``` php
        $original = new Response(200, ['X-Foo' => 'Bar', 'X-Bar' => 'private-token-065a1bb33f000032ab'], 'The content');

        $recorder = new FilesystemRecorder($this->workspace, $this->filesystem, [
            '!private-token-[0-9a-z]+!' => 'private-token-xxxx',
            '!The content!' => 'The big content'
        ]);
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
