### PR TITLE
Bump minimum versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - 7.4
@@ -23,7 +22,7 @@ branches:
 matrix:
     fast_finish: true
     include:
-        - php: 7.1
+        - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable" COVERAGE=true TEST_COMMAND="composer test-ci"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "guzzlehttp/psr7": "^1.4",
+        "php": "^7.2",
+        "guzzlehttp/psr7": "^1.7",
         "php-http/client-common": "^2.0",
         "psr/log": "^1.1",
         "symfony/filesystem": "^3.4|^4.0|^5.0",

--- a/src/Recorder/FilesystemRecorder.php
+++ b/src/Recorder/FilesystemRecorder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Http\Client\Plugin\Vcr\Recorder;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Message;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -74,7 +74,7 @@ final class FilesystemRecorder implements RecorderInterface, PlayerInterface, Lo
             throw new \RuntimeException(sprintf('Unable to read "%s" file content', $filename));
         }
 
-        return Psr7\parse_response($content);
+        return Message::parseResponse($content);
     }
 
     public function record(string $name, ResponseInterface $response): void
@@ -82,7 +82,7 @@ final class FilesystemRecorder implements RecorderInterface, PlayerInterface, Lo
         $filename = "{$this->directory}$name.txt";
         $context = compact('name', 'filename');
 
-        if (null === $content = preg_replace(array_keys($this->filters), array_values($this->filters), Psr7\str($response))) {
+        if (null === $content = preg_replace(array_keys($this->filters), array_values($this->filters), Message::toString($response))) {
             throw new \RuntimeException('Some of the provided response filters are invalid.');
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes

Bump minimum version to PHP 7.2 & `guzzlehttp/psr7:1.7`